### PR TITLE
Add domainname flag for appending a domain name to wordlist of hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,23 @@ Usage: VhostFinder -ip 10.8.0.1 -wordlist domains.txt
   -verify
     	Verify vhost is different than public url
   -wordlist string
-    	File of domain names to fuzz for
+    	File of domain names or host names to fuzz for
+  -domainname string
+      (Optional) Specify a domain name to append to wordlist of hostnames/subdomains
+```
+
+### Examples:
+```bash
+  VhostFinder -ip 10.8.0.1 -wordlist domains.txt
+  [!] Finding vhosts!
+  [!] Obtaining baseline
+  [+] host.example.com
+
+  VhostFinder -ip 10.8.0.1 -wordlist hostnames.txt -domainname host1.example.com -v
+  [!] Finding vhosts!
+  [!] Obtaining baseline
+  [+] admin.host1.example.com
+  [-] test.host1.example.com
 ```
 
 # What is Virtual Host Fuzzing?

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Usage: VhostFinder -ip 10.8.0.1 -wordlist domains.txt
   -wordlist string
     	File of domain names or host names to fuzz for
   -domainname string
-      (Optional) Specify a domain name to append to wordlist of hostnames/subdomains
+      Specify domain name or list of comma seperated 
+      domain names to append to wordlist of hostnames/subdomains
 ```
 
 ### Examples:
@@ -42,6 +43,16 @@ Usage: VhostFinder -ip 10.8.0.1 -wordlist domains.txt
   [!] Obtaining baseline
   [+] admin.host1.example.com
   [-] test.host1.example.com
+
+  VhostFinder -ip 10.8.0.1 -wordlist hostnames.txt -domainname host1.example.com,anotherdomain.net,host2.example.com -v
+  [!] Finding vhosts!
+  [!] Obtaining baseline
+  [+] admin.host1.example.com
+  [-] test.host1.example.com
+  [-] admin.anotherdomain.net
+  [-] test.anotherdomain.net
+  [+] admin.host2.example.com
+  [-] test.host2.example.com
 ```
 
 # What is Virtual Host Fuzzing?

--- a/README.md
+++ b/README.md
@@ -11,24 +11,23 @@ go install -v github.com/wdahlenburg/VhostFinder@latest
 
 ```
 Usage: VhostFinder -ip 10.8.0.1 -wordlist domains.txt
+  -domains string
+      Optional domain or comma seperated list to append to a subdomain wordlist (Ex: example1.com,example2.com)
   -ip string
-    	IP Address to Fuzz
+      IP Address to Fuzz
   -path string
-    	Custom path to send during fuzzing (default "/")
+      Custom path to send during fuzzing (default "/")
   -port int
-    	Port to use (default 443)
+      Port to use (default 443)
   -threads int
-    	Number of threads to use (default 10)
+      Number of threads to use (default 10)
   -tls
-    	Use TLS (Default: true) (default true)
-  -v	Verbose mode
+      Use TLS (default true)
+  -v  Verbose mode
   -verify
-    	Verify vhost is different than public url
+      Verify vhost is different than public url
   -wordlist string
-    	File of domain names or host names to fuzz for
-  -domainname string
-      Specify domain name or list of comma seperated 
-      domain names to append to wordlist of hostnames/subdomains
+      File of FQDNs or subdomain prefixes to fuzz for
 ```
 
 ### Examples:
@@ -38,13 +37,13 @@ Usage: VhostFinder -ip 10.8.0.1 -wordlist domains.txt
   [!] Obtaining baseline
   [+] host.example.com
 
-  VhostFinder -ip 10.8.0.1 -wordlist hostnames.txt -domainname host1.example.com -v
+  VhostFinder -ip 10.8.0.1 -wordlist subdomains.txt -domains host1.example.com -v
   [!] Finding vhosts!
   [!] Obtaining baseline
   [+] admin.host1.example.com
   [-] test.host1.example.com
 
-  VhostFinder -ip 10.8.0.1 -wordlist hostnames.txt -domainname host1.example.com,anotherdomain.net,host2.example.com -v
+  VhostFinder -ip 10.8.0.1 -wordlist subdomains.txt -domains host1.example.com,anotherdomain.net,host2.example.com -v
   [!] Finding vhosts!
   [!] Obtaining baseline
   [+] admin.host1.example.com

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	flag.StringVar(&ip, "ip", "", "IP Address to Fuzz")
 	flag.StringVar(&wordlist, "wordlist", "", "File of domain or host names to fuzz for")
-	flag.StringVar(&domainname, "domainname", "", "Specify a domain name to append to wordlist of hostnames/subdomains" )
+	flag.StringVar(&domainname, "domainname", "", "Specify domain name or list of comma seperated \ndomain names to append to wordlist of hostnames/subdomains")
 	flag.IntVar(&threads, "threads", 10, "Number of threads to use")
 	flag.BoolVar(&tls, "tls", true, "Use TLS (Default: true)")
 	flag.BoolVar(&verbose, "v", false, "Verbose mode")

--- a/main.go
+++ b/main.go
@@ -3,28 +3,30 @@ package main
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/wdahlenburg/VhostFinder/utils"
 )
 
 func main() {
 	var (
-		ip      	string
-		wordlist    string
-		domainname 	string
-		threads 	int
-		port    	int
-		tls     	bool
-		verbose 	bool
-		verify  	bool
-		path    	string
+		ip         string
+		wordlist   string
+		domains    string
+		domainList []string
+		threads    int
+		port       int
+		tls        bool
+		verbose    bool
+		verify     bool
+		path       string
 	)
 
 	flag.StringVar(&ip, "ip", "", "IP Address to Fuzz")
-	flag.StringVar(&wordlist, "wordlist", "", "File of domain or host names to fuzz for")
-	flag.StringVar(&domainname, "domainname", "", "Specify domain name or list of comma seperated \ndomain names to append to wordlist of hostnames/subdomains")
+	flag.StringVar(&wordlist, "wordlist", "", "File of FQDNs or subdomain prefixes to fuzz for")
+	flag.StringVar(&domains, "domains", "", "Optional domain or comma seperated list to append to a subdomain wordlist (Ex: example1.com,example2.com)")
 	flag.IntVar(&threads, "threads", 10, "Number of threads to use")
-	flag.BoolVar(&tls, "tls", true, "Use TLS (Default: true)")
+	flag.BoolVar(&tls, "tls", true, "Use TLS")
 	flag.BoolVar(&verbose, "v", false, "Verbose mode")
 	flag.BoolVar(&verify, "verify", false, "Verify vhost is different than public url")
 	flag.StringVar(&path, "path", "/", "Custom path to send during fuzzing")
@@ -38,17 +40,26 @@ func main() {
 		return
 	}
 
+	if len(strings.TrimSpace(domains)) > 0 {
+		for _, domain := range strings.Split(domains, ",") {
+			domain = strings.TrimSpace(domain)
+			if len(domain) > 0 {
+				domainList = append(domainList, domain)
+			}
+		}
+	}
+
 	fmt.Printf("[!] Finding vhosts!\n")
 	opts := &utils.Options{
-		Ip:       	ip,
-		Wordlist: 	wordlist,
-		DomainName: domainname,
-		Threads:  	threads,
-		Tls:      	tls,
-		Verbose:  	verbose,
-		Verify:   	verify,
-		Path:     	path,
-		Port:     	port,
+		Ip:       ip,
+		Wordlist: wordlist,
+		Domains:  domainList,
+		Threads:  threads,
+		Tls:      tls,
+		Verbose:  verbose,
+		Verify:   verify,
+		Path:     path,
+		Port:     port,
 	}
 	utils.EnumerateVhosts(opts)
 }

--- a/main.go
+++ b/main.go
@@ -9,18 +9,20 @@ import (
 
 func main() {
 	var (
-		ip      string
+		ip      	string
 		wordlist    string
-		threads int
-		port    int
-		tls     bool
-		verbose bool
-		verify  bool
-		path    string
+		domainname 	string
+		threads 	int
+		port    	int
+		tls     	bool
+		verbose 	bool
+		verify  	bool
+		path    	string
 	)
 
 	flag.StringVar(&ip, "ip", "", "IP Address to Fuzz")
-	flag.StringVar(&wordlist, "wordlist", "", "File of domain names to fuzz for")
+	flag.StringVar(&wordlist, "wordlist", "", "File of domain or host names to fuzz for")
+	flag.StringVar(&domainname, "domainname", "", "Specify a domain name to append to wordlist of hostnames/subdomains" )
 	flag.IntVar(&threads, "threads", 10, "Number of threads to use")
 	flag.BoolVar(&tls, "tls", true, "Use TLS (Default: true)")
 	flag.BoolVar(&verbose, "v", false, "Verbose mode")
@@ -38,14 +40,15 @@ func main() {
 
 	fmt.Printf("[!] Finding vhosts!\n")
 	opts := &utils.Options{
-		Ip:       ip,
-		Wordlist: wordlist,
-		Threads:  threads,
-		Tls:      tls,
-		Verbose:  verbose,
-		Verify:   verify,
-		Path:     path,
-		Port:     port,
+		Ip:       	ip,
+		Wordlist: 	wordlist,
+		DomainName: domainname,
+		Threads:  	threads,
+		Tls:      	tls,
+		Verbose:  	verbose,
+		Verify:   	verify,
+		Path:     	path,
+		Port:     	port,
 	}
 	utils.EnumerateVhosts(opts)
 }

--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -1,46 +1,38 @@
 package utils
 
 import (
-	"strings"
 	"bufio"
+	"fmt"
 	"os"
 )
 
-func ReadDomains(wordlist string, tld string) ([]string, []string, error) {
+func ReadDomains(wordlist string, domainList []string) ([]string, error) {
 	var domains []string
-	var domainNames []string
+	var dnSet bool = len(domainList) > 0
 
 	f, err := os.Open(wordlist)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 
-	// If domain name was set
-	// User has the ability to set multiple domain names, seperated by a comma
-	// We split the domainname string by the comma 
-	if len(strings.TrimSpace(tld)) > 0 {
-		dn := strings.Split(tld, ",")
-		for _, d := range dn {
-			d = strings.TrimSpace(d)
-			//If we have an empty index, skip it
-			if len(d) == 0 {
-				continue
+	for scanner.Scan() {
+		guess := scanner.Text()
+		if dnSet {
+			for _, domain := range domainList {
+				domains = append(domains, fmt.Sprintf("%s.%s", guess, domain))
 			}
-			domainNames = append(domainNames, d)
+		} else {
+			domains = append(domains, guess)
 		}
 	}
 
-	for scanner.Scan() {
-		domains = append(domains, scanner.Text())
-	}
-
 	if err := scanner.Err(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return domains, domainNames, nil
+	return domains, nil
 }

--- a/utils/file_utils.go
+++ b/utils/file_utils.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
+	"strings"
 	"bufio"
+	"fmt"
 	"os"
 )
 
-func ReadDomains(wordlist string) ([]string, error) {
+func ReadDomains(wordlist string, tld string) ([]string, error) {
 	var domains []string
 	f, err := os.Open(wordlist)
 
@@ -17,8 +19,19 @@ func ReadDomains(wordlist string) ([]string, error) {
 
 	scanner := bufio.NewScanner(f)
 
+	var tldSet bool = len(strings.TrimSpace(tld)) > 0
+
 	for scanner.Scan() {
-		domains = append(domains, scanner.Text())
+		
+		if tldSet {
+			// If domain name was set, prepend line to domain name
+			// This assumes the user supplied a list of hostnames/subdomains that doesn't contain the domain name 
+			fullDomain := fmt.Sprintf("%s.%s", strings.TrimSpace(scanner.Text()), strings.TrimSpace(tld))
+			domains = append(domains, fullDomain)
+		} else {
+			domains = append(domains, scanner.Text())
+		}
+		
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,18 +9,19 @@ import (
 )
 
 type Options struct {
-	Ip       string
-	Wordlist string
-	Threads  int
-	Port     int
-	Tls      bool
-	Verbose  bool
-	Verify   bool
-	Path     string
+	Ip       	string
+	Wordlist 	string
+	DomainName  string
+	Threads  	int
+	Port     	int
+	Tls      	bool
+	Verbose  	bool
+	Verify   	bool
+	Path     	string
 }
 
 func EnumerateVhosts(opts *Options) {
-	domains, err := ReadDomains(opts.Wordlist)
+	domains, err := ReadDomains(opts.Wordlist, opts.DomainName)
 	if err != nil {
 		fmt.Printf(err.Error())
 	}


### PR DESCRIPTION
Hey @wdahlenburg

I added a new optional flag to specify a domain name, for use as an option when a wordlist only contains hostnames. 
This allows a user to specify a domain name with a wordlist of hostnames, such as using a subdomain list from SecList, without the user needing to generate a new wordlist of hostname.domainname pairs. Really, the burden creation is put on the app and allows the user to quickly test multiple domain names against a static hostname wordlist.

If set, the domain name will be appended to each hostname within the wordlist before being added to the domains array. When not set, your original functionality is applied where each domain/hostname within the wordlist is added to the domains array without any pre-processing.

The README has also been updated to reflect these changes and provide some usage examples.

Let me know what needs to be changed!