### PR TITLE
Set default TLS to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	flagSet.StringVar(&opt.proxy, "proxy", "", "Proxy (Ex: http://127.0.0.1:8080)")
 	flagSet.IntVarP(&opt.threads, "threads", "t", 10, "Number of threads to use")
 	flagSet.IntVar(&opt.timeout, "timeout", 8, "Timeout per HTTP request")
-	flagSet.BoolVar(&opt.tls, "tls", true, "Use TLS")
+	flagSet.BoolVar(&opt.tls, "tls", false, "Use TLS")
 	flagSet.BoolVarP(&opt.verbose, "verbose", "v", false, "Verbose mode")
 	flagSet.BoolVar(&opt.verify, "verify", false, "Verify vhost is different than public url")
 


### PR DESCRIPTION
If the TLS default is true, then there is no way we scan http for Vhosts.